### PR TITLE
Pass auth0 jwt along with GraphQL requests

### DIFF
--- a/api/generated/api-schema.graphql
+++ b/api/generated/api-schema.graphql
@@ -17,6 +17,12 @@ type HammerPackages {
 }
 
 type Query {
+  currentUser: User
   hammer: Hammer!
   help: String!
+}
+
+type User {
+  email: String!
+  id: Int!
 }

--- a/api/src/functions/graphql.js
+++ b/api/src/functions/graphql.js
@@ -1,5 +1,14 @@
 import { graphQLServerlessFunction } from "@hammerframework/hammer-api";
+import { getCurrentUser } from "src/lib/auth0";
 
-export const SERVERLESS_FUNCTION_TYPE = "aws";
+const createHandler = async event => {
+  const currentUser = await getCurrentUser(event);
+  const server = graphQLServerlessFunction({
+    currentUser
+  });
+  return server.createHandler();
+};
 
-export const handler = graphQLServerlessFunction();
+export const handler = (event, context, callback) => {
+  createHandler(event).then(handler => handler(event, context, callback));
+};

--- a/api/src/functions/test.js
+++ b/api/src/functions/test.js
@@ -1,85 +1,11 @@
-import jwt from "jsonwebtoken";
-import jwksClient from "jwks-rsa";
-import dotenv from "dotenv";
-import fetch from "node-fetch";
+import { getCurrentUser } from "src/lib/auth0";
 
-import { user } from "src/services";
+export const handler = async (event, context, callback) => {
+  const user = await getCurrentUser(event);
 
-// hammer base dir.
-dotenv.config({ path: "../../.env" });
-
-// TODO: Move these into specialized auth0 package.
-const tokenFromEvent = event => {
-  if (!event.headers.authorization && !event.headers.authorization.length) {
-    return undefined;
-  }
-  return event.headers.authorization.split(" ")[1];
-};
-
-const userProfileForToken = async token => {
-  const response = await fetch(`https://${process.env.AUTH0_DOMAIN}/userinfo`, {
-    headers: {
-      Authorization: `Bearer ${token}`
-    }
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `Could not get user profile: ${response.status} ${response.body}`
-    );
-  }
-
-  const userProfile = await response.json();
-  return userProfile;
-};
-
-const decodeVerifiedToken = token => {
-  return new Promise((resolve, reject) => {
-    const { AUTH0_DOMAIN, AUTH0_AUDIENCE, AUTH0_KID } = process.env;
-    if (!AUTH0_DOMAIN || !AUTH0_KID || !AUTH0_AUDIENCE) {
-      throw new Error(
-        "`AUTH0_DOMAIN`, `AUTH0_KID` and `AUTH0_AUDIENCE` env vars are not set"
-      );
-    }
-
-    const client = jwksClient({
-      cache: true,
-      rateLimit: true,
-      jwksUri: `https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`
-    });
-
-    client.getSigningKey(process.env.AUTH0_KID, (keyError, { publicKey }) => {
-      if (keyError) {
-        return reject(keyError);
-      }
-
-      jwt.verify(
-        token,
-        publicKey,
-        {
-          algorithms: ["RS256"],
-          audience: AUTH0_AUDIENCE,
-          issuer: `https://${process.env.AUTH0_DOMAIN}/`
-        },
-        (verifyError, decoded) => {
-          if (verifyError) {
-            return reject(verifyError);
-          }
-          resolve(decoded);
-        }
-      );
-    });
-  });
-};
-
-export const handler = async event => {
-  const token = tokenFromEvent(event);
-  const userProfile = await userProfileForToken(token);
-  // here we can get the email, and generate an account,
-  // or retrieve an account.
-  const { email } = userProfile;
-  await user.findOrCreate({ email });
   return {
-    body: userProfile
+    body: {
+      user
+    }
   };
 };

--- a/api/src/graphql/currentUser.js
+++ b/api/src/graphql/currentUser.js
@@ -1,0 +1,22 @@
+import { extendType, intArg, objectType } from "nexus";
+
+export const User = objectType({
+  name: "User",
+  definition(t) {
+    t.int("id");
+    t.string("email");
+  }
+});
+
+export default extendType({
+  type: "Query",
+  definition: t => {
+    t.field("currentUser", {
+      type: "User",
+      nullable: true,
+      resolve(_root, _args, { currentUser }) {
+        return currentUser;
+      }
+    });
+  }
+});

--- a/api/src/lib/auth0.js
+++ b/api/src/lib/auth0.js
@@ -1,0 +1,83 @@
+import jwt from "jsonwebtoken";
+import jwksClient from "jwks-rsa";
+import dotenv from "dotenv";
+import fetch from "node-fetch";
+import { getHammerBaseDir } from "@hammerframework/hammer-api";
+
+import { user } from "src/services";
+
+dotenv.config({ path: `${getHammerBaseDir()}/.env` });
+
+// TODO: Move this to @hammerframework/hammer-api-auth0
+const tokenFromEvent = event => {
+  if (typeof event.headers.authorization === "undefined") {
+    return undefined;
+  }
+  return event.headers.authorization.split(" ")[1];
+};
+
+const userProfileForToken = async token => {
+  const response = await fetch(`https://${process.env.AUTH0_DOMAIN}/userinfo`, {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Could not get user profile: ${response.status} ${response.body}`
+    );
+  }
+
+  const userProfile = await response.json();
+  return userProfile;
+};
+
+const decodeVerifiedToken = token => {
+  return new Promise((resolve, reject) => {
+    const { AUTH0_DOMAIN, AUTH0_AUDIENCE, AUTH0_KID } = process.env;
+    if (!AUTH0_DOMAIN || !AUTH0_KID || !AUTH0_AUDIENCE) {
+      throw new Error(
+        "`AUTH0_DOMAIN`, `AUTH0_KID` and `AUTH0_AUDIENCE` env vars are not set"
+      );
+    }
+
+    const client = jwksClient({
+      cache: true,
+      rateLimit: true,
+      jwksUri: `https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`
+    });
+
+    client.getSigningKey(process.env.AUTH0_KID, (keyError, { publicKey }) => {
+      if (keyError) {
+        return reject(keyError);
+      }
+
+      jwt.verify(
+        token,
+        publicKey,
+        {
+          algorithms: ["RS256"],
+          audience: AUTH0_AUDIENCE,
+          issuer: `https://${process.env.AUTH0_DOMAIN}/`
+        },
+        (verifyError, decoded) => {
+          if (verifyError) {
+            return reject(verifyError);
+          }
+          resolve(decoded);
+        }
+      );
+    });
+  });
+};
+
+export const getCurrentUser = async event => {
+  try {
+    const token = tokenFromEvent(event);
+    const { email } = await userProfileForToken(token);
+    return await user.findOrCreate({ email });
+  } catch (e) {
+    return null;
+  }
+};

--- a/packages/hammer-api/src/api/functions/graphql.ts
+++ b/packages/hammer-api/src/api/functions/graphql.ts
@@ -10,7 +10,7 @@ require("@babel/register")({
   ignore: ["node_modules"]
 });
 
-export const graphQLServerlessFunction = ({ context = {} } = {}) => {
+export const graphQLServerlessFunction = (context = undefined) => {
   const hammerConfig = getHammerConfig();
 
   const BaseQueryType = queryType({
@@ -19,7 +19,7 @@ export const graphQLServerlessFunction = ({ context = {} } = {}) => {
         resolve() {
           return `Start adding your Nexus schema definitions in ${
             hammerConfig.api.paths.graphql
-          }, read more over here: "https://hammerframework.com/"`;
+          }`;
         }
       });
     }
@@ -40,10 +40,8 @@ export const graphQLServerlessFunction = ({ context = {} } = {}) => {
     }
   });
 
-  const server = new ApolloServer({
+  return new ApolloServer({
     schema,
     context
   });
-
-  return server.createHandler();
 };

--- a/packages/hammer-dev-server/package.json
+++ b/packages/hammer-dev-server/package.json
@@ -24,6 +24,6 @@
     "babel-plugin-module-resolver": "^3.2.0"
   },
   "scripts": {
-    "dev": "nodemon --watch ../../api/src/ --exec babel-node --extensions \".ts,.tsx\" ./src/main.ts"
+    "dev": "nodemon --watch ../../api/src/ --exec 'babel-node --extensions \".ts,.tsx\" ./src/main.ts'"
   }
 }

--- a/packages/hammer-web/src/index.js
+++ b/packages/hammer-web/src/index.js
@@ -1,13 +1,20 @@
 import React from "react";
-import { Provider, createClient } from "urql";
+import { Provider } from "urql";
+import { createClient } from "urql";
+import gql from "graphql-tag";
+
 export { useMutation, useQuery } from "urql";
-
-export gql from "graphql-tag";
-
 export { default as Query } from "./graphql/Query";
+export { gql };
 
-export const client = createClient({
+const DEFAULT_CLIENT_CONFIG = {
   url: "/.netlify/functions/graphql"
-});
+};
 
-export const GraphQLProvider = props => <Provider value={client} {...props} />;
+const newCreateClient = config =>
+  createClient({ ...DEFAULT_CLIENT_CONFIG, ...config });
+export { newCreateClient as createClient };
+
+export const GraphQLProvider = ({ client = newCreateClient(), ...rest }) => (
+  <Provider client={client} {...rest} />
+);

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -1,8 +1,8 @@
 import ReactDOM from "react-dom";
-import { GraphQLProvider } from "@hammerframework/hammer-web";
-import { ThemeProvider } from "styled-components";
 
-import { Auth0Provider } from "src/lib/auth0";
+import { Auth0Provider, GraphQLWithAuth0Provider } from "src/lib/auth0";
+
+import { ThemeProvider } from "styled-components";
 
 import theme from "src/lib/theme";
 import Routes from "src/pages/Routes";
@@ -10,19 +10,19 @@ import Routes from "src/pages/Routes";
 import "./index.css";
 
 ReactDOM.render(
-  <GraphQLProvider>
-    <ThemeProvider theme={theme}>
-      <Auth0Provider
-        config={{
-          domain: process.env.AUTH0_DOMAIN,
-          client_id: process.env.AUTH0_CLIENT_ID,
-          audience: process.env.AUDIENCE,
-          redirect_uri: window.location.origin
-        }}
-      >
+  <Auth0Provider
+    config={{
+      domain: process.env.AUTH0_DOMAIN,
+      client_id: process.env.AUTH0_CLIENT_ID,
+      audience: process.env.AUDIENCE,
+      redirect_uri: window.location.origin
+    }}
+  >
+    <GraphQLWithAuth0Provider>
+      <ThemeProvider theme={theme}>
         <Routes />
-      </Auth0Provider>
-    </ThemeProvider>
-  </GraphQLProvider>,
+      </ThemeProvider>
+    </GraphQLWithAuth0Provider>
+  </Auth0Provider>,
   document.getElementById("hammer-app")
 );

--- a/web/src/lib/auth0/auth0.js
+++ b/web/src/lib/auth0/auth0.js
@@ -1,2 +1,22 @@
+import { GraphQLProvider, createClient } from "@hammerframework/hammer-web";
+
 export { Auth0Provider, useAuth0 } from "./Auth0Provider";
 export { default as SecureRoute } from "./SecureRoute";
+
+export const GraphQLWithAuth0Provider = ({ audience, ...rest }) => {
+  return (
+    <GraphQLProvider
+      client={createClient({
+        fetchOptions: async () => {
+          const token = await useAuth0().getTokenSilently({ audience });
+          return {
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
+          };
+        }
+      })}
+      {...rest}
+    />
+  );
+};


### PR DESCRIPTION


### on the web side...
GraphQL requests now pass along the `jwt` from Auth0:

https://github.com/hammerframework/billable/blob/72ba3a1988e4e9052db6e5a833479d673e87657c/web/src/lib/auth0/auth0.js#L8-L20

The `getTokenSilently()` call is cached automatically by auth0.

### on the api side...

We grab our public key from auth0, which we use to verify that the `jwt` which we are decoding is valid.
https://github.com/hammerframework/billable/blob/0fa415d8163a57d0fddc7cd2ebba3d1451339c80/api/src/lib/auth0.js#L45-L71

The public key is cached, but we could improve this for cold starts if we introduced some way to cache things (maybe via redis.)

Verified key in hand, we're able to associate that token to a user in the database, which we pump into the GraphQL context:
https://github.com/hammerframework/billable/blob/9d5b162c5cd71ed9fe7c502b76a0f8b4e56497d5/api/src/functions/graphql.js#L5-L8

Which we resolve on the `currentUser` field in GraphQL:

https://github.com/hammerframework/billable/blob/14fb0181f9bfb9bea97920cf14ad75b30adba87f/api/src/graphql/currentUser.js#L11-L22

