### PR TITLE
Pass auth0 token through GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Auth0 requires a bit of configuration, go ahead and add these to a `.env` file i
 ```env
 AUTH0_DOMAIN=p4p8.eu.auth0.com
 AUTH0_CLIENT_ID=b7vN4sVz6yjGrq82ctXJW9NRTvlWzkFU
-AUTH0_AUDIENCE=BILLABLE_API
 AUTH0_KID=MkE1RkVENTc3RjcxRUVGNUE0MTY3NDk2RTBCN0Y2RTA5NDBCQ0UzRg
 ```
 
@@ -45,7 +44,7 @@ This command will eventually move into the `hammer-cli`.
 Run `yarn open` to open your browser on `http://localhost:8910`.
 
 Browse to `http://localhost:8910` to see the web app. Lambda functions run on
-`localhost:8911` but are proxied to `localhost:8910/.netlify/functions/*`.
+`localhost:8911` but are proxied to `localhost:8910/api/functions/*`.
 
 ## Development
 

--- a/hammer.toml
+++ b/hammer.toml
@@ -1,11 +1,9 @@
-# Hammer - Build something.
-
 [web]
-  port=8910
+  port = 8910
+  apiProxyPath = "/api/functions"
 
 [api]
-  port=8911
-  
+  port = 8911  
   [api.paths]
   functions = './api/src/functions'
   graphql = './api/src/graphql'

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "@hammerframework/hammer-cli": "^0.0.0-alpha.5"
   },
   "scripts": {
-    "dev": "yarn build:hammer && yarn dev:api & yarn dev:web",
+    "dev": "yarn build:hammer && (yarn dev:api & yarn dev:web)",
     "open": "open http://localhost:8910",
     "dev:api": "yarn workspace api dev",
     "dev:web": "yarn workspace web dev",
-    "build:hammer": "yarn workspace @hammerframework/hammer-api build & yarn workspace @hammerframework/hammer-web build",
-    "build:hammer:watch": "yarn workspace @hammerframework/hammer-api build:watch & yarn workspace @hammerframework/hammer-web build:watch"
+    "build:hammer": "yarn workspace @hammerframework/hammer-api build && yarn workspace @hammerframework/hammer-web build",
+    "build:hammer:watch": "yarn workspace @hammerframework/hammer-api build:watch && yarn workspace @hammerframework/hammer-web build:watch"
   }
 }

--- a/packages/hammer-api/package.json
+++ b/packages/hammer-api/package.json
@@ -26,7 +26,7 @@
     "ttypescript": "^1.5.7"
   },
   "scripts": {
-    "build": "yarn clean && yarn build:js && yarn build:types",
+    "build": "yarn clean && yarn build:types && yarn build:js",
     "build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline",
     "build:types": "ttsc --declaration --emitDeclarationOnly",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'",

--- a/packages/hammer-api/src/core.ts
+++ b/packages/hammer-api/src/core.ts
@@ -25,6 +25,7 @@ export interface HammerConfig {
   baseDir: string;
   web: {
     port: number;
+    apiProxyPath: string;
   };
   api: {
     port: number;

--- a/packages/hammer-web/package.json
+++ b/packages/hammer-web/package.json
@@ -11,7 +11,7 @@
     "proptypes": "^1.1.0",
     "react-content-loader": "^4.2.1",
     "graphql": "^14.4.2",
-    "urql": "^1.1.3"
+    "urql": "^1.2.0"
   },
   "scripts": {
     "build": "yarn clean && babel src -d dist",

--- a/packages/hammer-web/src/graphql/Query/index.js
+++ b/packages/hammer-web/src/graphql/Query/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Query as OriginalQuery } from "urql";
+import { Query } from "urql";
 
 import Skeleton from "./subcomponents/Skeleton";
 
@@ -20,10 +20,11 @@ import Skeleton from "./subcomponents/Skeleton";
  * urql RenderProps: https://formidable.com/open-source/urql/docs/api/#render-props
  */
 export default ({ children, component: Component, ...rest }) => {
-  const { query, skeleton, dataToProps } = Component.queryProps;
+  const { query, skeleton, dataToProps } =
+    (Component && Component.queryProps) || rest;
 
   return (
-    <OriginalQuery query={query} {...rest}>
+    <Query query={query} {...rest}>
       {({ fetching: loading, error, data, executeQuery: refetch }) => {
         if (loading) {
           if (typeof skeleton !== "undefined") {
@@ -53,6 +54,6 @@ export default ({ children, component: Component, ...rest }) => {
         // the component.
         return <Component {...cleanData} refetch={refetch} />;
       }}
-    </OriginalQuery>
+    </Query>
   );
 };

--- a/packages/hammer-web/src/index.js
+++ b/packages/hammer-web/src/index.js
@@ -1,20 +1,21 @@
 import React from "react";
-import { Provider } from "urql";
-import { createClient } from "urql";
 import gql from "graphql-tag";
+import {
+  Provider as RealProvider,
+  createClient as realCreateClient
+} from "urql";
 
 export { useMutation, useQuery } from "urql";
 export { default as Query } from "./graphql/Query";
 export { gql };
 
 const DEFAULT_CLIENT_CONFIG = {
-  url: "/.netlify/functions/graphql"
+  url: `${__HAMMER__.apiProxyPath}/graphql`
 };
 
-const newCreateClient = config =>
-  createClient({ ...DEFAULT_CLIENT_CONFIG, ...config });
-export { newCreateClient as createClient };
+export const createClient = config =>
+  realCreateClient({ ...DEFAULT_CLIENT_CONFIG, ...config });
 
-export const GraphQLProvider = ({ client = newCreateClient(), ...rest }) => (
-  <Provider client={client} {...rest} />
-);
+export const GraphQLProvider = ({ client = createClient(), ...rest }) => {
+  return <RealProvider value={client} {...rest} />;
+};

--- a/web/config/webpack.common.js
+++ b/web/config/webpack.common.js
@@ -4,8 +4,9 @@ const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const DirectoryNamedWebpackPlugin = require("directory-named-webpack-plugin");
 const Dotenv = require("dotenv-webpack");
+const { getHammerConfig } = require("@hammerframework/hammer-api");
 
-console.log(path.resolve(__dirname, "../../.env"));
+const hammerConfig = getHammerConfig();
 
 module.exports = {
   entry: {
@@ -20,9 +21,8 @@ module.exports = {
       PropTypes: "prop-types",
       gql: ["@hammerframework/hammer-web", "gql"]
     }),
-    new Dotenv({
-      // billable base-directory
-      path: path.resolve(__dirname, "../../.env")
+    new webpack.DefinePlugin({
+      "__HAMMER__.apiProxyPath": JSON.stringify(hammerConfig.web.apiProxyPath)
     })
   ],
   module: {

--- a/web/config/webpack.dev.js
+++ b/web/config/webpack.dev.js
@@ -1,23 +1,33 @@
 /* eslint-disable import/no-extraneous-dependencies */
-const path = require('path');
-const merge = require('webpack-merge');
+const path = require("path");
+const merge = require("webpack-merge");
+const Dotenv = require("dotenv-webpack");
+const { getHammerConfig } = require("@hammerframework/hammer-api");
+const escapeRegExp = require("lodash.escaperegexp");
 
-const common = require('./webpack.common.js');
+const common = require("./webpack.common.js");
+
+const hammerConfig = getHammerConfig();
 
 module.exports = merge(common, {
-  mode: 'development',
-  devtool: 'inline-source-map',
+  mode: "development",
+  devtool: "inline-source-map",
   devServer: {
     historyApiFallback: true,
-    contentBase: path.resolve(__dirname, '../dist'),
-    port: 8910,
+    contentBase: path.resolve(__dirname, "../dist"),
+    port: hammerConfig.web.port,
     proxy: {
-      '/.netlify/functions': {
-        target: 'http://localhost:8911',
+      [hammerConfig.web.apiProxyPath]: {
+        target: `http://localhost:${hammerConfig.api.port}`,
         pathRewrite: {
-          '^/\\.netlify/functions': '',
-        },
-      },
-    },
+          [`^${escapeRegExp(hammerConfig.web.apiProxyPath)}`]: ""
+        }
+      }
+    }
   },
+  plugins: [
+    new Dotenv({
+      path: `${hammerConfig.baseDir}/.env`
+    })
+  ]
 });

--- a/web/package.json
+++ b/web/package.json
@@ -27,11 +27,13 @@
     "dotenv-webpack": "^1.7.0",
     "file-loader": "^4.0.0",
     "html-webpack-plugin": "^3.2.0",
+    "lodash.escaperegexp": "^4.1.2",
     "style-loader": "^0.23.1",
     "webpack": "^4.35.2",
     "webpack-cli": "^3.3.5",
     "webpack-dev-server": "^3.7.2",
-    "webpack-merge": "^4.2.1"
+    "webpack-merge": "^4.2.1",
+    "@hammerframework/hammer-api": "0.0.0"
   },
   "scripts": {
     "dev": "webpack-dev-server --config config/webpack.dev.js",

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -1,9 +1,7 @@
 import ReactDOM from "react-dom";
-
-import { Auth0Provider, GraphQLWithAuth0Provider } from "src/lib/auth0";
-
 import { ThemeProvider } from "styled-components";
 
+import { Auth0Provider, Auth0GraphQLProvider } from "src/lib/auth0";
 import theme from "src/lib/theme";
 import Routes from "src/pages/Routes";
 
@@ -14,15 +12,14 @@ ReactDOM.render(
     config={{
       domain: process.env.AUTH0_DOMAIN,
       client_id: process.env.AUTH0_CLIENT_ID,
-      audience: process.env.AUDIENCE,
       redirect_uri: window.location.origin
     }}
   >
-    <GraphQLWithAuth0Provider>
+    <Auth0GraphQLProvider>
       <ThemeProvider theme={theme}>
         <Routes />
       </ThemeProvider>
-    </GraphQLWithAuth0Provider>
+    </Auth0GraphQLProvider>
   </Auth0Provider>,
   document.getElementById("hammer-app")
 );

--- a/web/src/lib/auth0/Auth0Provider.js
+++ b/web/src/lib/auth0/Auth0Provider.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useContext } from "react";
+import PropTypes from "prop-types";
 import createAuth0Client from "@auth0/auth0-spa-js";
 
 export const Auth0Context = React.createContext();
@@ -63,4 +64,12 @@ export const Auth0Provider = ({ children, config }) => {
       {children}
     </Auth0Context.Provider>
   );
+};
+
+Auth0Provider.propTypes = {
+  config: PropTypes.shape({
+    domain: PropTypes.string.isRequired,
+    client_id: PropTypes.string.isRequired,
+    redirect_uri: PropTypes.string.isRequired
+  })
 };

--- a/web/src/lib/auth0/SecureRoute.js
+++ b/web/src/lib/auth0/SecureRoute.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Route } from "react-router-dom";
 
 import { useAuth0 } from "./";

--- a/web/src/lib/auth0/auth0.js
+++ b/web/src/lib/auth0/auth0.js
@@ -1,22 +1,30 @@
-import { GraphQLProvider, createClient } from "@hammerframework/hammer-web";
+import { useEffect, useState } from "react";
 
-export { Auth0Provider, useAuth0 } from "./Auth0Provider";
-export { default as SecureRoute } from "./SecureRoute";
+import { createClient, GraphQLProvider } from "@hammerframework/hammer-web";
 
-export const GraphQLWithAuth0Provider = ({ audience, ...rest }) => {
-  return (
-    <GraphQLProvider
-      client={createClient({
-        fetchOptions: async () => {
-          const token = await useAuth0().getTokenSilently({ audience });
-          return {
+import { Auth0Provider, useAuth0 } from "./Auth0Provider";
+import { default as SecureRoute } from "./SecureRoute";
+
+export { Auth0Provider, useAuth0, SecureRoute };
+
+export const Auth0GraphQLProvider = props => {
+  const [client, setClient] = useState();
+  const { isAuthenticated, getTokenSilently } = useAuth0();
+
+  useEffect(() => {
+    const fn = async () => {
+      const token = await getTokenSilently();
+      setClient(
+        createClient({
+          fetchOptions: {
             headers: {
               Authorization: `Bearer ${token}`
             }
-          };
-        }
-      })}
-      {...rest}
-    />
-  );
+          }
+        })
+      );
+    };
+    isAuthenticated && fn();
+  }, [isAuthenticated]);
+  return <GraphQLProvider client={client} {...props} />;
 };

--- a/web/src/pages/Test/Test.js
+++ b/web/src/pages/Test/Test.js
@@ -13,8 +13,7 @@ const ExternalApi = () => {
       });
 
       console.log("token", token);
-
-      const response = await fetch("/.netlify/functions/test", {
+      const response = await fetch(`${__HAMMER__.apiProxyPath}/test`, {
         headers: {
           Authorization: `Bearer ${token}`
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4564,6 +4564,11 @@ lock@~0.1.2:
   resolved "https://registry.yarnpkg.com/lock/-/lock-0.1.4.tgz#fec7deaef17e7c3a0a55e1da042803e25d91745d"
   integrity sha1-/sfervF+fDoKVeHaBCgD4l2RdF0=
 
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+  integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -7162,10 +7167,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.1.3.tgz#41fffb0a3b1a3f7ac47be55b7f84ca69875e7358"
-  integrity sha512-H6xdtT+b3n7OYG1U/ItLHTBfBpM0Kxd6FkQSYP1TvylqUeyz160whRu/XpwDRt2VwbLy5+j729wv4BF1f1zP4Q==
+urql@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.2.0.tgz#82b5dc49a7c22c4640ed3415f1fb9f2f6bf71b36"
+  integrity sha512-rAk9ExBpdmkvFXfYbgXM2pg2x5Lpnm0aJYNYriWsOYWKVxmoX+LJIZb0xGPWE3hPxXl9Q17Y+H+4yW1JVAuHhQ==
   dependencies:
     fast-json-stable-stringify "^2.0.0"
     graphql-tag "^2.10.1"


### PR DESCRIPTION
This PR also allows the `web-to-api` proxy path to be configured in `hammer.toml`, changing the default from `http://localhost:8910/.netlify/api/functions*` to `http://localhost:8910/api/functions/*`