### PR TITLE
ESLint configuration to auto-sort imports

### DIFF
--- a/api/src/functions/graphql.js
+++ b/api/src/functions/graphql.js
@@ -1,6 +1,6 @@
 import { graphQLServerlessFunction } from '@hammerframework/hammer-api'
-import { getAccessToken } from 'src/lib/auth0'
 
+import { getAccessToken } from 'src/lib/auth0'
 import { users } from 'src/services'
 
 const server = graphQLServerlessFunction({

--- a/api/src/graphql/invoices.js
+++ b/api/src/graphql/invoices.js
@@ -29,7 +29,7 @@ export const extendMutation = extendType({
 export const extendQuery = extendType({
   type: 'Query',
   definition: (t) => {
-    t.field('invoicesNewest', {
+    t.list.field('invoices', {
       type: 'Invoice',
       nullable: true,
       async resolve (_root, _args, { currentUser }) {

--- a/api/src/services/invoices.js
+++ b/api/src/services/invoices.js
@@ -13,6 +13,23 @@ export const create = async ({ id, user, body }) => {
   })
 }
 
+export const all = async ({ user }) => {
+  const invoices = await db().invoices.findMany({
+    where: {
+      User: user,
+    },
+    orderBy: {
+      createdAt: 'asc',
+    },
+    first: 1,
+  })
+
+  if (!invoices) {
+    return null
+  }
+  return invoices[0]
+}
+
 export const newest = async ({ user }) => {
   const invoices = await db().invoices.findMany({
     where: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typescript": "^3.5.3",
     "@babel/preset-typescript": "^7.3.3",
     "@hammerframework/hammer-cli": "^0.0.0-alpha.5",
-    "@hammerframework/eslint-config-hammer": "0.0.1-alpha.7"
+    "@hammerframework/eslint-config-hammer": "0.0.1-alpha.8"
   },
   "dependencies": {},
   "scripts": {

--- a/packages/eslint-config-hammer/index.js
+++ b/packages/eslint-config-hammer/index.js
@@ -90,5 +90,7 @@ module.exports = {
       },
     ],
     'react/display-name': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
   },
 }

--- a/packages/eslint-config-hammer/index.js
+++ b/packages/eslint-config-hammer/index.js
@@ -1,13 +1,15 @@
-// Hammerframework's ESLint configuration is a mixture between ESLint's
-// recommended rules[1], React's recommended rules[2], and a bit of our stylistic
+// Hammer's ESLint configuration is a mixture between ESLint's recommended
+// rules [^1], React's recommended rules [^2], and a bit of our stylistic
 // flair:
 // - no semicolons
 // - comma dangle when multiline
 // - single quotes
-// - always use parens around arrow functions
+// - always use parenthesis around arrow functions
+// - enforced import sorting
 //
-// 1. https://eslint.org/docs/rules/
-// 2. https://www.npmjs.com/package/eslint-plugin-react#list-of-supported-rules
+// [^1] https://eslint.org/docs/rules/
+// [^2] https://www.npmjs.com/package/eslint-plugin-react#list-of-supported-rules
+
 module.exports = {
   parser: 'babel-eslint',
   extends: [
@@ -19,6 +21,9 @@ module.exports = {
   settings: {
     react: {
       version: 'detect',
+    },
+    'import/resolver': {
+      'babel-module': {},
     },
   },
   env: {
@@ -34,6 +39,23 @@ module.exports = {
     __HAMMER__: 'readyonly',
   },
   rules: {
+    // We disable rules related to code formatting that are aleady covered
+    // by prettier based on their recommendation:
+    //
+    // semi: ['error', 'never'],
+    // 'comma-dangle': ['error', 'always-multiline'],
+    // quotes: [
+    //   'error',
+    //   'single',
+    //   { avoidEscape: true, allowTemplateLiterals: true },
+    // ],
+    // 'arrow-parens': ['error', 'always'],
+    // 'object-curly-spacing': ['error', 'always'],
+
+    // Code formatting rules not covered by prettier
+    'space-before-function-paren': ['error', 'always'],
+
+    //
     'prefer-object-spread': 'warn',
     'prefer-spread': 'warn',
     'no-unused-expressions': [
@@ -44,18 +66,22 @@ module.exports = {
     camelcase: ['warn', { properties: 'never' }],
     'no-new': 'warn',
     'new-cap': ['error', { newIsCap: true, capIsNew: false }],
-    'space-before-function-paren': ['error', 'always'],
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-    semi: ['error', 'never'],
-    'comma-dangle': ['error', 'always-multiline'],
-    quotes: [
+    'import/order': [
       'error',
-      'single',
-      { avoidEscape: true, allowTemplateLiterals: true },
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+        ],
+        'newlines-between': 'always',
+      },
     ],
-    'arrow-parens': ['error', 'always'],
-    'object-curly-spacing': ['error', 'always'],
-    // react rules
+    // React rules
     'react/prop-types': [
       'error',
       {

--- a/packages/eslint-config-hammer/package.json
+++ b/packages/eslint-config-hammer/package.json
@@ -2,14 +2,12 @@
   "name": "@hammerframework/eslint-config-hammer",
   "version": "0.0.1-alpha.8",
   "main": "index.js",
-  "files": [
-    "index.js"
-  ],
   "license": "MIT",
   "dependencies": {
     "babel-eslint": "^10.0.3",
     "eslint": "5.16.0",
     "eslint-config-prettier": "^6.2.0",
+    "eslint-import-resolver-babel-module": "^5.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.0",

--- a/packages/hammer-web/src/HammerProvider.js
+++ b/packages/hammer-web/src/HammerProvider.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
 import { ThemeProvider as RealThemeProvider } from 'styled-components'
+
 import { GraphQLProvider as RealGraphQLProvider } from 'src/graphql'
 
 let USE_AUTH

--- a/packages/hammer-web/src/Router.js
+++ b/packages/hammer-web/src/Router.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
+
 import { useAuth } from './HammerProvider'
 
 export const AuthRoute = ({ component: Component, path, ...rest }) => {

--- a/web/src/components/AppBar.js
+++ b/web/src/components/AppBar.js
@@ -1,4 +1,5 @@
 import { useAuth } from '@hammerframework/hammer-web'
+
 import { Flex, Box, Button } from 'src/lib/primitives'
 
 export default () => {

--- a/web/src/components/Invoice/Invoice.js
+++ b/web/src/components/Invoice/Invoice.js
@@ -1,4 +1,5 @@
 import { forwardRef, useImperativeHandle, useState } from 'react'
+
 import { Flex } from 'src/lib/primitives'
 
 import TextInput from '../TextInput'

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom'
-import { HammerProvider } from '@hammerframework/hammer-web'
 import { initAuth } from '@hammerframework/hammer-auth-auth0'
+import { HammerProvider } from '@hammerframework/hammer-web'
 
 import theme from 'src/lib/theme'
 import Routes from 'src/pages/Routes'

--- a/web/src/pages/InvoicePage/InvoicePage.js
+++ b/web/src/pages/InvoicePage/InvoicePage.js
@@ -1,9 +1,9 @@
 import { useState, useRef, useEffect } from 'react'
 import { useAuth, useQuery } from '@hammerframework/hammer-web'
+import { useMutation } from '@apollo/react-hooks'
 
 import { Box, Button } from 'src/lib/primitives'
 import { AppBar, Invoice } from 'src/components'
-import { useMutation } from '@apollo/react-hooks'
 
 const LOCALSTORAGE_KEY = 'invoice'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,6 +958,25 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@hammerframework/hammer-api@0.0.1-alpha.7":
+  version "0.0.1-alpha.7"
+  resolved "https://registry.yarnpkg.com/@hammerframework/hammer-api/-/hammer-api-0.0.1-alpha.7.tgz#9eefda08b1c926385609db98d484a8ff12514cfb"
+  integrity sha512-wtI87npxESZQBAZlnua77NnaGSNKL9rqTnZ1kkgh7tIKBV8OmB65VcUYAN9vIutsc9vpiP+iOfogHze9Qk9y1A==
+  dependencies:
+    "@babel/register" "^7.5.5"
+    "@hammerframework/hammer-core" "^0.0.1-alpha.7"
+    apollo-server-lambda "^2.9.3"
+    findup-sync "^3.0.0"
+    graphql "^14.5.4"
+
+"@hammerframework/hammer-auth-auth0@0.0.1-alpha.7":
+  version "0.0.1-alpha.7"
+  resolved "https://registry.yarnpkg.com/@hammerframework/hammer-auth-auth0/-/hammer-auth-auth0-0.0.1-alpha.7.tgz#5d92f91428cb907b2ec4088fd99a8c9b49285f16"
+  integrity sha512-eEfyltw6uLHPLlNCe+kLqE7GyO7mxYSBsfu44XCVjV37F/Y9k7jaBuOyF+yCVcoY9wJ5WbJWCnq2JWlWPR3NEA==
+  dependencies:
+    "@auth0/auth0-spa-js" "^1.0.2"
+    "@hammerframework/hammer-web" "^0.0.1-alpha.7"
+
 "@hammerframework/hammer-cli@^0.0.0-alpha.5":
   version "0.0.0-alpha.5"
   resolved "https://registry.yarnpkg.com/@hammerframework/hammer-cli/-/hammer-cli-0.0.0-alpha.5.tgz#51e45c6ac39bbbaab18eea9e6acde27036f71cd4"
@@ -970,6 +989,30 @@
     react "^16.8.6"
     require-dir "^1.2.0"
     yargs-parser "^13.1.1"
+
+"@hammerframework/hammer-core@0.0.1-alpha.7":
+  version "0.0.1-alpha.7"
+  resolved "https://registry.yarnpkg.com/@hammerframework/hammer-core/-/hammer-core-0.0.1-alpha.7.tgz#9a829da673b51417a3915a9dfcd46abcf8ef71b9"
+  integrity sha512-LNpC2PG/5pxb74s9VOgmGeogyJWtJD4lnpkHZqraGQfkM4u58UfVcGKp8Z2tCeK7j5eKCYsBugSYf3iFNsdnyg==
+  dependencies:
+    findup-sync "^3.0.0"
+    toml "^3.0.0"
+
+"@hammerframework/hammer-web@0.0.1-alpha.7":
+  version "0.0.1-alpha.7"
+  resolved "https://registry.yarnpkg.com/@hammerframework/hammer-web/-/hammer-web-0.0.1-alpha.7.tgz#54d2f3f3a6e6a9b60f397daf0c594ea9ce498ed6"
+  integrity sha512-xO0Lyry9ao+5iAFjWkgODREys9r+Uisd8FJ2ASy4DK87PGQmtIDeP1VdDS/VGMixnbhS8DR9Y3X+hKVxVwJwrA==
+  dependencies:
+    "@apollo/react-components" "^3.0.1"
+    "@apollo/react-hooks" "^3.0.1"
+    apollo-boost "^0.4.4"
+    apollo-cache "^1.3.2"
+    apollo-client "^2.6.4"
+    apollo-link "^1.2.12"
+    apollo-utilities "^1.3.2"
+    graphql "^14.5.4"
+    proptypes "^1.1.0"
+    react-content-loader "^4.2.2"
 
 "@jimp/bmp@^0.5.4":
   version "0.5.4"
@@ -4982,6 +5025,14 @@ eslint-config-prettier@^6.2.0:
   integrity sha512-VLsgK/D+S/FEsda7Um1+N8FThec6LqE3vhcMyp8mlmto97y3fGf3DX7byJexGuOb1QY0Z/zz222U5t+xSfcZDQ==
   dependencies:
     get-stdin "^6.0.0"
+
+eslint-import-resolver-babel-module@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-babel-module/-/eslint-import-resolver-babel-module-5.1.0.tgz#50dac176dfbce2824b0e12100d6c23370d4325c0"
+  integrity sha512-fnWkQ9+fVjQ4H9qk5sH8zUfC8TPyWJAakLPjLqUgdlexhyT6PGk8AieXuEvdeskIXLOcO2WLI4kothFBigjFjA==
+  dependencies:
+    pkg-up "^2.0.0"
+    resolve "^1.10.0"
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"


### PR DESCRIPTION
This makes ESLint automatically format our imports with a space between import "blocks".

```js
// 1. node "builtin" modules
import fs from 'fs';
import path from 'path';
// 2. "external" modules
import _ from 'lodash';
import chalk from 'chalk';
// 3. "internal" modules
// (if you have configured your path or webpack to handle your internal paths differently)
import foo from 'src/foo';
// 4. modules from a "parent" directory
import foo from '../foo';
import qux from '../../foo/qux';
// 5. "sibling" modules from the same or a sibling's directory
import bar from './bar';
import baz from './bar/baz';
// 6. "index" of the current directory
import main from './';
```